### PR TITLE
lets make sure we can focus on the filter search input 

### DIFF
--- a/src/multiselect.js
+++ b/src/multiselect.js
@@ -273,7 +273,9 @@ angular.module('ui.multiselect', [])
 
         scope.focus = function focus(){
           var searchBox = element.find('input')[0];
-          searchBox.focus(); 
+          if (searchBox) {
+            searchBox.focus();
+          }
         }
 
         var elementMatchesAnyInArray = function (element, elementArray) {


### PR DESCRIPTION
I have overwritten template and removed filter search input field. Then I got javascript error where it cannot .focus() on the input as it doesnt exist.

Here is a quick check if it exists as a fix.

Any comments/amends please let me know
