### PR TITLE
Redefine isEmpty to do check for empty arrays; for Angular 1.2

### DIFF
--- a/src/multiselect.js
+++ b/src/multiselect.js
@@ -34,6 +34,11 @@ angular.module('ui.multiselect', [])
         restrict: 'E',
         require: 'ngModel',
         link: function (originalScope, element, attrs, modelCtrl) {
+          //Redefine isEmpty - this allows this to work on at least Angular 1.2.x
+          var isEmpty = modelCtrl.$isEmpty;
+          modelCtrl.$isEmpty = function(value) {
+            return isEmpty(value) || (angular.isArray(value) && value.length == 0);
+          };
 
           var exp = attrs.options,
             parsedResult = optionParser.parse(exp),


### PR DESCRIPTION
At the moment, required does not appear to work when there is more than one multiselect instances on a form.   (for at least angular 1.2). This fixes that.