### PR TITLE
FInd html templates at the script path level

### DIFF
--- a/src/multiselect.js
+++ b/src/multiselect.js
@@ -262,7 +262,7 @@ angular.module('ui.multiselect', [])
           
           if( fileMatch ){
             filePath = currentScriptPath.slice(0, fileMatch.index);
-            break;i
+            break;
           }
           
         }

--- a/src/multiselect.js
+++ b/src/multiselect.js
@@ -252,8 +252,23 @@ angular.module('ui.multiselect', [])
       scope: false,
       replace: true,
       templateUrl: function (element, attr) {
-                return attr.templateUrl || 'multiselect.tmpl.html';
-        },
+
+        var scripts = document.getElementsByTagName("script");
+        var filePath = '';
+        
+        for(var scriptKey in scripts){
+          var currentScriptPath = scripts[scriptKey].src;
+          var fileMatch = currentScriptPath.match('multiselect.js');
+          
+          if( fileMatch ){
+            filePath = currentScriptPath.slice(0, fileMatch.index);
+            break;i
+          }
+          
+        }
+
+	return attr.templateUrl || filePath+'multiselect.tmpl.html';
+      },
       link: function (scope, element, attrs) {
 
         scope.isVisible = false;


### PR DESCRIPTION
HI,
I've had an issue about find the templates after installing your plugin using bower, so I solved this by searching the templates in the path that contains the main script.

I think that it can be improved, but it can save a time for now, because the devs wont have to change the path mannually.

Ty.