### PR TITLE
Use original scope for evaluating expressions

### DIFF
--- a/src/multiselect.js
+++ b/src/multiselect.js
@@ -114,8 +114,8 @@ angular.module('ui.multiselect', [])
               var local = {};
               local[parsedResult.itemName] = model[i];
               scope.items.push({
-                label: parsedResult.viewMapper(local),
-                model: parsedResult.modelMapper(local),
+                label: parsedResult.viewMapper(originalScope, local),
+                model: parsedResult.modelMapper(originalScope, local),
                 checked: false
               });
             }
@@ -149,7 +149,8 @@ angular.module('ui.multiselect', [])
               }else{
                 var local = {};
                 local[parsedResult.itemName] = modelCtrl.$modelValue;
-                scope.header = parsedResult.viewMapper(local) || scope.items[modelCtrl.$modelValue].label;
+                scope.header = parsedResult.viewMapper(originalScope, local)
+                    || scope.items[modelCtrl.$modelValue].label;
               }
             }
           }


### PR DESCRIPTION
allows this kind of syntax:
options="c as names[c] for c in cars"
Example: http://plnkr.co/edit/kuazqOFoL16YqhNZsDfT?p=preview