### PR TITLE
this removes unused gulp tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,13 +11,9 @@ var gulp = require('gulp'),
     sequence = require('run-sequence'),
     mergeStream = require('merge-stream'),
     concat = require('gulp-concat'),
-    minify = require('gulp-ngmin'),
-    order = require('gulp-order'),
-    jshint = require('gulp-jshint'),
     lintspaces = require("gulp-lintspaces"),
     templateCache = require("gulp-angular-templatecache"),
     angularFilesort = require("gulp-angular-filesort"),
-    jshintsummary = require('jshint-summary'),
     lintspacesConfig = {
         indentation: 'spaces',
         spaces: 4,
@@ -49,28 +45,6 @@ gulp.task('whitespace', function() {
             'src/*.css'])
         .pipe(lintspaces(lintspacesConfig))
         .pipe(lintspaces.reporter());
-});
-
-/* For Future Use -- Currently not used */
-gulp.task('scripts', function() {
-    return gulp.src('src/*.js')
-        .pipe(order([
-            "app.js",
-            "multiselect.js",
-            "multiselect-tpls.js"]))
-        .pipe(jshint.reporter('jshint-summary', {
-            verbose: true,
-            reasonCol: 'cyan,bold',
-            codeCol: 'green'
-        }))
-        .pipe(gulp.dest('dist'));
-});
-
-/* For future use to compress */
-gulp.task('compress', function() {
-    return gulp.src('src/*.js')
-        .pipe(minify({dynamic: true}))
-        .pipe(gulp.dest('dist'));
 });
 
 gulp.task('js', ['build-multiselect-tpls.js'], function () {

--- a/package.json
+++ b/package.json
@@ -10,13 +10,9 @@
     "gulp-angular-filesort": "^1.1.1",
     "gulp-angular-templatecache": "^1.7.0",
     "gulp-concat": "^2.6.0",
-    "gulp-jshint": "^1.11.2",
     "gulp-lintspaces": "^0.3.1",
-    "gulp-ngmin": "^0.3.0",
-    "gulp-order": "^1.1.1",
     "gulp-uglify": "^1.4.1",
     "gulp-watch": "^4.3.5",
-    "jshint-summary": "^0.4.0",
     "merge-stream": "^1.0.0",
     "run-sequence": "^1.1.4"
   },


### PR DESCRIPTION
I'd like to remove these unused tasks. I know @naga2raja put some good hard work into this, so didn't just push to master.

Benefits to removing:
 - `gulp-ngmin` is deprecated and causes warnings during `npm install`
 - will speed up `npm install` a bit
 - less code, less dependencies, helps signal to noise ratio

Benefits to keeping:
 - less work when time comes for development of these tasks
 - serves as a reminder to work on these

I'd say we should either push to implement these in the next couple days or pull out the dead code with this PR.

Thoughts @amitava82, @naga2raja?