### PR TITLE
Allow empty ms-header attribute.

### DIFF
--- a/src/multiselect.js
+++ b/src/multiselect.js
@@ -122,7 +122,7 @@ angular.module('am.multiselect', [])
         element.append($compile(popUpEl)(scope));
 
         function getHeaderText() {
-            if (is_empty(modelCtrl.$modelValue)) return scope.header = attrs.msHeader || 'Select';
+            if (is_empty(modelCtrl.$modelValue)) return scope.header = (attrs.msHeader!==undefined ? attrs.msHeader : 'Select');
 
             if (isMultiple) {
                 if (attrs.msSelected) {


### PR DESCRIPTION
I couldn't use the multiselect without placeholder. Due to the OR comparator an empty string like ms-header="" would be ignored and the default was used.
