### PR TITLE
Uncheck all for single should uncheck ALL, not filtered elements.

### DIFF
--- a/dist/multiselect-tpls.js
+++ b/dist/multiselect-tpls.js
@@ -228,7 +228,7 @@ angular.module('am.multiselect', [])
         };
 
         scope.uncheckAll = function () {
-            var items = (scope.searchText && scope.searchText.label.length > 0) ? $filter('filter')(scope.items, scope.searchText) : scope.items;
+            var items = (isMultiple && scope.searchText && scope.searchText.label.length > 0) ? $filter('filter')(scope.items, scope.searchText) : scope.items;
             angular.forEach(items, function (item) {
                 item.checked = false;
             });

--- a/dist/multiselect.js
+++ b/dist/multiselect.js
@@ -228,7 +228,7 @@ angular.module('am.multiselect', [])
         };
 
         scope.uncheckAll = function () {
-            var items = (scope.searchText && scope.searchText.label.length > 0) ? $filter('filter')(scope.items, scope.searchText) : scope.items;
+            var items = (isMultiple && scope.searchText && scope.searchText.label.length > 0) ? $filter('filter')(scope.items, scope.searchText) : scope.items;
             angular.forEach(items, function (item) {
                 item.checked = false;
             });

--- a/src/multiselect.js
+++ b/src/multiselect.js
@@ -228,7 +228,7 @@ angular.module('am.multiselect', [])
         };
 
         scope.uncheckAll = function () {
-            var items = (scope.searchText && scope.searchText.label.length > 0) ? $filter('filter')(scope.items, scope.searchText) : scope.items;
+            var items = (isMultiple && scope.searchText && scope.searchText.label.length > 0) ? $filter('filter')(scope.items, scope.searchText) : scope.items;
             angular.forEach(items, function (item) {
                 item.checked = false;
             });


### PR DESCRIPTION
Uncheck all for single should uncheck ALL, not filtered elements.

Why? Because for single select filter is used to find next option to select. If we select it, we should uncheck all previously checked options.